### PR TITLE
Fixed main script entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Include `restful.min.js` to the HTML, and the `restful` object is now available 
 Alternately, you can use [RequireJS](http://requirejs.org/) or [Browserify](http://browserify.org/) to avoid global scoping.
 
 ```js
-var restful = require('restful');
+var restful = require('restful.js');
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "make test"
   },
+  "main": "dist/restful.min.js",
   "author": "Robin Bressan <robin@buddey.net>",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
1. First of all your package is called restful.js not restful. Please fix a wiki or change package name
```javascript
var restful = require('restful'); // exception module not found
var restful = require('restful.js'); // works
```

2. For now it doesn't works:

```javascript
var restful = require('restful.js'); // exception: Cannot find module 'restful.js.
```

Please add "main" entry to package.json. Now it works fine. 