### PR TITLE
Handle empty body on fetch response

### DIFF
--- a/src/http/fetch.js
+++ b/src/http/fetch.js
@@ -15,7 +15,10 @@ export default function(fetch) {
 
         return fetch(!queryString.length ? url : `${url}?${queryString}`, config)
             .then((response) => {
-                return (response.status === 204 ? Promise.resolve(null) : response.json()).then((json) => {
+                return response.text().then((text) => {
+                    return JSON.parse(text || '{}');
+                })
+                .then((json) => {
                     const headers = {};
 
                     response.headers.forEach((value, name) => {

--- a/test/src/http/fetchSpec.js
+++ b/test/src/http/fetchSpec.js
@@ -14,6 +14,7 @@ describe('Fetch HTTP Backend', () => {
                     cb('here', 'test');
                 },
             },
+			      text: sinon.stub().returns(Promise.resolve('{ "content": "Yes" }')),
             json: sinon.stub().returns(Promise.resolve({ content: 'Yes' })),
             status: 200,
         };
@@ -96,8 +97,9 @@ describe('Fetch HTTP Backend', () => {
         .catch(done);
     });
 
-    it('should correctly format the response when it succeed and returns 204 as status code', (done) => {
+    it('should correctly format the response when body content is empty', (done) => {
         response.status = 204;
+        response.text = sinon.stub().returns(Promise.resolve(''));
         httpBackend({
             data: {
                 me: 'you',
@@ -112,7 +114,7 @@ describe('Fetch HTTP Backend', () => {
         })
         .then((_response) => {
             expect(_response).to.deep.equal({
-                data: null,
+                data: {},
                 headers: {
                     test: 'here',
                 },


### PR DESCRIPTION
Currently the fetch will attempt to call json.parse on the body which throws if the body is empty. Don't think the check for a 204 is enough because from the HTTP spec:

*4.3 Message Body*

*... All 1xx (informational), 204 (no content), and 304 (not modified) responses MUST NOT include a message-body. All other responses do include a message-body, although* **it MAY be of zero length.**

Also I'm using it in a real world scenario where I'm returning a 401 with no body content. I've replaced the .json call with an evaluation of the response text and the a json.parse of an empty object if the text length is zero. A try parse on the text would probably have been better but i don't know a decent way of doing it.

I didn't dig too deep and there may well be a better approach to this or the possibility to move it into the .json function - also the tests might be pony.

:ghost: