### PR TITLE
Headers access fix in FF v43.0.3 and Safari v9.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ commentsCollection.get(4).then((response) => {
 ### Response
 A response is made from the HTTP response fetched from the endpoint. It exposes `statusCode()`, `headers()`, and `body()` methods. For a `GET` request, the `body` method will return one or an array of entities. Therefore you can disable this hydration by calling `body(false)`.
 
+#### Headers 
+
+For most of cases, `headers` in a response will be a plain object with headers data, but for some browsers, that don't support iteration over [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) object, it will simply be returned as a [Headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers), so you can use `get` method from it to get required headers.
+    
 ### Entity Data
 
 An entity is made from the HTTP response data fetched from the endpoint. It exposes a `data()` method:

--- a/src/http/fetch.js
+++ b/src/http/fetch.js
@@ -34,10 +34,19 @@ export default function (fetch) {
         return fetch(!queryString.length ? url : `${url}?${queryString}`, config)
             .then((response) => {
                 return parseBody(response).then((json) => {
-                    const headers = {};
-                    const keys = response.headers.keys();
-                    for (const key of keys) {
-                        headers[key] = response.headers.get(key);
+                    let headers = {};
+
+                    if (typeof Headers.prototype.forEach === 'function') {
+                        response.headers.forEach((value, name) => {
+                            headers[name] = value
+                        })
+                    } else if (typeof Headers.prototype.keys === 'function') {
+                        const keys = response.headers.keys();
+                        for (const key of keys) {
+                            headers[key] = response.headers.get(key);
+                        }
+                    } else {
+                        headers = response.headers
                     }
 
                     const responsePayload = {

--- a/test/src/http/fetchSpec.js
+++ b/test/src/http/fetchSpec.js
@@ -7,6 +7,9 @@ describe('Fetch HTTP Backend', () => {
     let fetch;
     let response;
 
+    global.Headers = () => {}
+    global.Headers.prototype.keys = () => {}
+    
     beforeEach(() => {
         response = {
             headers: {


### PR DESCRIPTION
Use different methods to get headers, depend on what is available: `forEach`, `keys` or simply return Headers object otherwise.

This PR is addressing the problem described in this issue: https://github.com/marmelab/restful.js/issues/76