### PR TITLE
Define all used HTTP methods as uppercase according to spec

### DIFF
--- a/src/model/endpoint.js
+++ b/src/model/endpoint.js
@@ -78,7 +78,7 @@ export default function(request) {
             addErrorInterceptor: addInterceptor('error'),
             addRequestInterceptor: addInterceptor('request'),
             addResponseInterceptor: addInterceptor('response'),
-            delete: _httpMethodFactory('delete'),
+            delete: _httpMethodFactory('DELETE'),
             identifier: newIdentifier => {
                 if (newIdentifier === undefined) {
                     return scope.get('config').get('entityIdentifier');
@@ -88,8 +88,8 @@ export default function(request) {
 
                 return endpoint;
             },
-            get: _httpMethodFactory('get', false),
-            head: _httpMethodFactory('head', false),
+            get: _httpMethodFactory('GET', false),
+            head: _httpMethodFactory('HEAD', false),
             header: (key, value) => scope.assign('headers', key, value),
             headers: () => scope.get('headers'),
             new: (url) => {
@@ -100,9 +100,9 @@ export default function(request) {
             },
             on: scope.on,
             once: scope.once,
-            patch: _httpMethodFactory('patch'),
-            post: _httpMethodFactory('post'),
-            put: _httpMethodFactory('put'),
+            patch: _httpMethodFactory('PATCH'),
+            post: _httpMethodFactory('POST'),
+            put: _httpMethodFactory('PUT'),
             url: () => scope.get('url'),
         });
 

--- a/test/src/model/endpointSpec.js
+++ b/test/src/model/endpointSpec.js
@@ -29,7 +29,7 @@ describe('Endpoint model', () => {
             expect(request.getCall(0).args[0].toJS()).to.deep.equal({
                 errorInterceptors: [],
                 headers: {},
-                method: 'get',
+                method: 'GET',
                 params: null,
                 requestInterceptors: [],
                 responseInterceptors: [],
@@ -45,7 +45,7 @@ describe('Endpoint model', () => {
                 headers: {
                     Authorization: 'Token xxxx',
                 },
-                method: 'get',
+                method: 'GET',
                 params: {
                     filter: 'asc',
                 },
@@ -72,7 +72,7 @@ describe('Endpoint model', () => {
                 headers: {
                     'Content-Type': 'application/json;charset=UTF-8',
                 },
-                method: 'post',
+                method: 'POST',
                 params: null,
                 requestInterceptors: [],
                 responseInterceptors: [],
@@ -100,7 +100,7 @@ describe('Endpoint model', () => {
                     'Content-Type': 'application/json;charset=UTF-8',
                     hello: 'world',
                 },
-                method: 'post',
+                method: 'POST',
                 params: {
                     goodbye: 'planet',
                 },
@@ -127,7 +127,7 @@ describe('Endpoint model', () => {
                 headers: {
                     'Content-Type': 'application/json;charset=UTF-8',
                 },
-                method: 'put',
+                method: 'PUT',
                 params: null,
                 requestInterceptors: [],
                 responseInterceptors: [],
@@ -155,7 +155,7 @@ describe('Endpoint model', () => {
                     'Content-Type': 'application/json;charset=UTF-8',
                     hello: 'world',
                 },
-                method: 'put',
+                method: 'PUT',
                 params: {
                     goodbye: 'planet',
                 },
@@ -182,7 +182,7 @@ describe('Endpoint model', () => {
                 headers: {
                     'Content-Type': 'application/json;charset=UTF-8',
                 },
-                method: 'patch',
+                method: 'PATCH',
                 params: null,
                 requestInterceptors: [],
                 responseInterceptors: [],
@@ -210,7 +210,7 @@ describe('Endpoint model', () => {
                     'Content-Type': 'application/json;charset=UTF-8',
                     hello: 'world',
                 },
-                method: 'patch',
+                method: 'PATCH',
                 params: {
                     goodbye: 'planet',
                 },
@@ -237,7 +237,7 @@ describe('Endpoint model', () => {
                 headers: {
                     'Content-Type': 'application/json;charset=UTF-8',
                 },
-                method: 'delete',
+                method: 'DELETE',
                 params: null,
                 requestInterceptors: [],
                 responseInterceptors: [],
@@ -265,7 +265,7 @@ describe('Endpoint model', () => {
                     'Content-Type': 'application/json;charset=UTF-8',
                     hello: 'world',
                 },
-                method: 'delete',
+                method: 'DELETE',
                 params: {
                     goodbye: 'planet',
                 },
@@ -283,7 +283,7 @@ describe('Endpoint model', () => {
             expect(request.getCall(0).args[0].toJS()).to.deep.equal({
                 errorInterceptors: [],
                 headers: {},
-                method: 'head',
+                method: 'HEAD',
                 params: null,
                 requestInterceptors: [],
                 responseInterceptors: [],
@@ -299,7 +299,7 @@ describe('Endpoint model', () => {
                 headers: {
                     Authorization: 'Token xxxx',
                 },
-                method: 'head',
+                method: 'HEAD',
                 params: {
                     filter: 'asc',
                 },
@@ -319,7 +319,7 @@ describe('Endpoint model', () => {
             expect(request.getCall(0).args[0].toJS()).to.deep.equal({
                 errorInterceptors: [],
                 headers: {},
-                method: 'get',
+                method: 'GET',
                 params: null,
                 requestInterceptors: [{ hello: 'world' }],
                 responseInterceptors: [],
@@ -335,7 +335,7 @@ describe('Endpoint model', () => {
             expect(request.getCall(0).args[0].toJS()).to.deep.equal({
                 errorInterceptors: [],
                 headers: {},
-                method: 'get',
+                method: 'GET',
                 params: null,
                 requestInterceptors: [],
                 responseInterceptors: [{ hello2: 'world2' }],
@@ -351,7 +351,7 @@ describe('Endpoint model', () => {
             expect(request.getCall(0).args[0].toJS()).to.deep.equal({
                 errorInterceptors: [{ hello3: 'world3' }],
                 headers: {},
-                method: 'get',
+                method: 'GET',
                 params: null,
                 requestInterceptors: [],
                 responseInterceptors: [],
@@ -371,7 +371,7 @@ describe('Endpoint model', () => {
                     Authorization: 'xxxx',
                     hello: 'world',
                 },
-                method: 'get',
+                method: 'GET',
                 params: null,
                 requestInterceptors: [],
                 responseInterceptors: [],
@@ -388,7 +388,7 @@ describe('Endpoint model', () => {
                 headers: {
                     Authorization: 'yyyy',
                 },
-                method: 'get',
+                method: 'GET',
                 params: null,
                 requestInterceptors: [],
                 responseInterceptors: [],
@@ -423,7 +423,7 @@ describe('Endpoint model', () => {
                 'Content-Type': 'application/json;charset=UTF-8',
                 hello: 'planet',
             },
-            method: 'post',
+            method: 'POST',
             params: null,
             requestInterceptors: [
                 { alpha: 'beta' },
@@ -446,7 +446,7 @@ describe('Endpoint model', () => {
             expect(listener.getCall(0).args[1]).to.deep.equal({
                 errorInterceptors: [],
                 headers: {},
-                method: 'get',
+                method: 'GET',
                 params: null,
                 requestInterceptors: [],
                 responseInterceptors: [],
@@ -471,7 +471,7 @@ describe('Endpoint model', () => {
                 {
                     errorInterceptors: [],
                     headers: {},
-                    method: 'get',
+                    method: 'GET',
                     params: null,
                     requestInterceptors: [],
                     responseInterceptors: [],
@@ -496,7 +496,7 @@ describe('Endpoint model', () => {
                 {
                     errorInterceptors: [],
                     headers: {},
-                    method: 'get',
+                    method: 'GET',
                     params: null,
                     requestInterceptors: [],
                     responseInterceptors: [],

--- a/test/src/service/httpSpec.js
+++ b/test/src/service/httpSpec.js
@@ -16,7 +16,7 @@ describe('HTTP Service', () => {
     });
 
     it('should execute request interceptors, then call the http backend and execute response interceptors before returning result', (done) => {
-        const requestInterceptor1 = sinon.stub().returns({ method: 'put' });
+        const requestInterceptor1 = sinon.stub().returns({ method: 'PUT' });
         const requestInterceptor2 = sinon.stub().returns({ params: { asc: 1 } });
         const requestInterceptor3 = sinon.stub().returns(new Promise((resolve) => {
             setTimeout(() => {
@@ -26,7 +26,7 @@ describe('HTTP Service', () => {
         const responseInterceptor1 = sinon.stub().returns({ status: 'yes' });
 
         http(Map({
-            method: 'get',
+            method: 'GET',
             form: {
                 test: 'test',
             },
@@ -37,7 +37,7 @@ describe('HTTP Service', () => {
             expect(emitter.getCall(0).args).to.deep.equal([
                 'request:interceptor:pre',
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -48,7 +48,7 @@ describe('HTTP Service', () => {
             expect(emitter.getCall(1).args).to.deep.equal([
                 'request:interceptor:post',
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -59,7 +59,7 @@ describe('HTTP Service', () => {
             expect(emitter.getCall(2).args).to.deep.equal([
                 'request:interceptor:pre',
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -70,7 +70,7 @@ describe('HTTP Service', () => {
             expect(emitter.getCall(3).args).to.deep.equal([
                 'request:interceptor:post',
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -84,7 +84,7 @@ describe('HTTP Service', () => {
             expect(emitter.getCall(4).args).to.deep.equal([
                 'request:interceptor:pre',
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -98,7 +98,7 @@ describe('HTTP Service', () => {
             expect(emitter.getCall(5).args).to.deep.equal([
                 'request:interceptor:post',
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -112,7 +112,7 @@ describe('HTTP Service', () => {
             expect(emitter.getCall(6).args).to.deep.equal([
                 'request',
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -128,7 +128,7 @@ describe('HTTP Service', () => {
                     output: 1,
                 },
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -146,7 +146,7 @@ describe('HTTP Service', () => {
                     status: 'yes',
                 },
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -159,7 +159,7 @@ describe('HTTP Service', () => {
             ]);
             expect(requestInterceptor1.getCall(0).args).to.deep.equal([
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -168,7 +168,7 @@ describe('HTTP Service', () => {
             ]);
             expect(requestInterceptor2.getCall(0).args).to.deep.equal([
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -177,7 +177,7 @@ describe('HTTP Service', () => {
             ]);
             expect(requestInterceptor3.getCall(0).args).to.deep.equal([
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -189,7 +189,7 @@ describe('HTTP Service', () => {
             ]);
             expect(httpBackend.getCall(0).args).to.deep.equal([
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -204,7 +204,7 @@ describe('HTTP Service', () => {
                     output: 1,
                 },
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -223,7 +223,7 @@ describe('HTTP Service', () => {
     });
 
     it('should execute error interceptors when an error occured in a request interceptor', (done) => {
-        const requestInterceptor1 = sinon.stub().returns({ method: 'put' });
+        const requestInterceptor1 = sinon.stub().returns({ method: 'PUT' });
         const requestInterceptor2 = sinon.stub().returns(new Promise(() => {
             throw new Error('Oops');
         }));
@@ -231,7 +231,7 @@ describe('HTTP Service', () => {
 
         http(Map({
             errorInterceptors: [errorInterceptor1],
-            method: 'get',
+            method: 'GET',
             form: {
                 test: 'test',
             },
@@ -242,7 +242,7 @@ describe('HTTP Service', () => {
             expect(emitter.getCall(0).args).to.deep.equal([
                 'request:interceptor:pre',
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -253,7 +253,7 @@ describe('HTTP Service', () => {
             expect(emitter.getCall(1).args).to.deep.equal([
                 'request:interceptor:post',
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -264,7 +264,7 @@ describe('HTTP Service', () => {
             expect(emitter.getCall(2).args).to.deep.equal([
                 'request:interceptor:pre',
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -276,7 +276,7 @@ describe('HTTP Service', () => {
                 'error:interceptor:pre',
                 new Error('Oops'),
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -290,7 +290,7 @@ describe('HTTP Service', () => {
                     status: 'yes',
                 },
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -300,7 +300,7 @@ describe('HTTP Service', () => {
             ]);
             expect(requestInterceptor1.getCall(0).args).to.deep.equal([
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -309,7 +309,7 @@ describe('HTTP Service', () => {
             ]);
             expect(requestInterceptor2.getCall(0).args).to.deep.equal([
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -320,7 +320,7 @@ describe('HTTP Service', () => {
             expect(errorInterceptor1.getCall(0).args).to.deep.equal([
                 new Error('Oops'),
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -340,7 +340,7 @@ describe('HTTP Service', () => {
 
         http(Map({
             errorInterceptors: [errorInterceptor1],
-            method: 'get',
+            method: 'GET',
             form: {
                 test: 'test',
             },
@@ -351,7 +351,7 @@ describe('HTTP Service', () => {
             expect(emitter.getCall(0).args).to.deep.equal([
                 'request',
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -364,7 +364,7 @@ describe('HTTP Service', () => {
                     output: 1,
                 },
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -376,7 +376,7 @@ describe('HTTP Service', () => {
                 'error:interceptor:pre',
                 new Error('Oops'),
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -390,7 +390,7 @@ describe('HTTP Service', () => {
                     status: 'yes',
                 },
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -403,7 +403,7 @@ describe('HTTP Service', () => {
                     output: 1,
                 },
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -412,7 +412,7 @@ describe('HTTP Service', () => {
             ]);
             expect(httpBackend.getCall(0).args).to.deep.equal([
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -422,7 +422,7 @@ describe('HTTP Service', () => {
             expect(errorInterceptor1.getCall(0).args).to.deep.equal([
                 new Error('Oops'),
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -436,13 +436,13 @@ describe('HTTP Service', () => {
 
 
     it('should execute error interceptors when an error occured in httpBackend', (done) => {
-        const requestInterceptor1 = sinon.stub().returns({ method: 'put' });
+        const requestInterceptor1 = sinon.stub().returns({ method: 'PUT' });
         const errorInterceptor1 = sinon.stub().returns({ status: 'yes' });
         httpBackend.returns(Promise.reject(new Error('Oops')));
 
         http(Map({
             errorInterceptors: [errorInterceptor1],
-            method: 'get',
+            method: 'GET',
             form: {
                 test: 'test',
             },
@@ -453,7 +453,7 @@ describe('HTTP Service', () => {
             expect(emitter.getCall(0).args).to.deep.equal([
                 'request:interceptor:pre',
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -464,7 +464,7 @@ describe('HTTP Service', () => {
             expect(emitter.getCall(1).args).to.deep.equal([
                 'request:interceptor:post',
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -475,7 +475,7 @@ describe('HTTP Service', () => {
             expect(emitter.getCall(2).args).to.deep.equal([
                 'request',
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -486,7 +486,7 @@ describe('HTTP Service', () => {
                 'error:interceptor:pre',
                 new Error('Oops'),
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -500,7 +500,7 @@ describe('HTTP Service', () => {
                     status: 'yes',
                 },
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -510,7 +510,7 @@ describe('HTTP Service', () => {
             ]);
             expect(requestInterceptor1.getCall(0).args).to.deep.equal([
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },
@@ -519,7 +519,7 @@ describe('HTTP Service', () => {
             ]);
             expect(httpBackend.getCall(0).args).to.deep.equal([
                 {
-                    method: 'put',
+                    method: 'PUT',
                     form: {
                         test: 'test',
                     },
@@ -529,7 +529,7 @@ describe('HTTP Service', () => {
             expect(errorInterceptor1.getCall(0).args).to.deep.equal([
                 new Error('Oops'),
                 {
-                    method: 'get',
+                    method: 'GET',
                     form: {
                         test: 'test',
                     },


### PR DESCRIPTION
This addresses #81 which breaks because fetch does not normalize the lowercase patch method to uppercase. Further, this changes all HTTP method definitions so that they do not rely on normalization of HTTP methods by the fetch dependency.